### PR TITLE
Fix random sutta index range

### DIFF
--- a/pali_bot/sutta_provider.py
+++ b/pali_bot/sutta_provider.py
@@ -111,5 +111,5 @@ class SuttaProvider:
         :return: Sutta
         :raises KeyError: if named section is not exists
         """
-        index = random.randint(0, self.get_section_length(section) - 1)
+        index = random.randint(1, self.get_section_length(section))
         return self.get_sutta(section=section, number=index)


### PR DESCRIPTION
Random sutta command used incorrect range for index so it was an error for the least index and never chosen last sutta in a section.